### PR TITLE
macholib 1.16.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ test:
   commands:
     - pip check
     - macho_dump --help
+    - macho_standalone --help
+    - macho_find --help
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ about:
   description: |
       macholib can be used to analyze and edit Mach-O headers,
       the executable format used by Mac OS X.
-  doc_url: https://macholib.readthedocs.io/en/latest/
+  doc_url: https://macholib.readthedocs.io
   dev_url: https://github.com/ronaldoussoren/macholib
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,6 @@ test:
   commands:
     - pip check
     - macho_dump --help
-    - macho_standalone --help
-    - macho_find --help
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "macholib" %}
-{% set version = "1.16.2" %}
-{% set sha256 = "557bbfa1bb255c20e9abafe7ed6cd8046b48d9525db2f9b77d3122a63a2a8bf8" %}
+{% set version = "1.16.3" %}
+{% set sha256 = "07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30" %}
 
 package:
   name: {{ name|lower }}
@@ -12,11 +12,12 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: true  #[py<38]
   entry_points:
     - macho_find = macholib.macho_find:main
     - macho_standalone = macholib.macho_standalone:main
     - macho_dump = macholib.macho_dump:main
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   number: 0
 
 requirements:
@@ -35,7 +36,6 @@ test:
   commands:
     - pip check
     - macho_dump --help
-    - python -m macholib find /tmp/
   requires:
     - pip
 


### PR DESCRIPTION
> ## `☆Macholib 1.16.3☆`
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6223)
> [Upstream](https://github.com/ronaldoussoren/macholib/tree/v1.16.3)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
> * Skip for python versions less than 3.8
 